### PR TITLE
Merchant Item Images

### DIFF
--- a/app/controllers/dashboard/dashboard_controller.rb
+++ b/app/controllers/dashboard/dashboard_controller.rb
@@ -2,5 +2,6 @@ class Dashboard::DashboardController < Dashboard::BaseController
   def index
     @merchant = current_user
     @pending_orders = Order.pending_orders_for_merchant(current_user.id)
+    @items_without_pictures = Item.items_without_pictures
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,11 +24,17 @@ class Item < ApplicationRecord
   end
 
   def self.item_popularity(limit, order)
-    Item.joins(:order_items)
-      .select('items.*, sum(quantity) as total_ordered')
-      .group(:id)
-      .order("total_ordered #{order}")
-      .limit(limit)
+     joins(:order_items)
+    .select('items.*, sum(quantity) as total_ordered')
+    .group(:id)
+    .order("total_ordered #{order}")
+    .limit(limit)
+  end
+
+  def self.items_without_pictures
+    default_image_url = "%https://picsum.photos/%"
+
+    where("items.image LIKE ?", default_image_url).order(:name)
   end
 
   def convert_datetime_to_seconds(datetime)

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -13,6 +13,14 @@
   </div>
 </div>
 
+<% if current_merchant? %>
+  <div class="to-do-list">
+    <section id="items-without-pictures">
+
+    </section>
+  </div>
+<% end %>
+
 <%= tag.div class: "card" do %>
   <%= tag.section class: "statistics card-body float-left m-4" do %>
     <%= tag.section id: "top-items-sold-by-quantity", class: "card-body float-left m-2" do %>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -15,9 +15,15 @@
 
 <% if current_merchant? %>
   <div class="to-do-list">
+    <h5>To-Do List</h5>
+    <% if @items_without_pictures %>
     <section id="items-without-pictures">
-
+      <p>Add photos for these items to increase sales:</p>
+      <% @items_without_pictures.each do |item| %>
+        <p><%= link_to item.name, item_path(item) %></p>
+      <% end %>
     </section>
+    <% end %>
   </div>
 <% end %>
 

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'merchant dashboard' do
         visit dashboard_path
 
         expect(page).to have_css(".to-do-list")
-        end
+      end
 
       scenario 'as an admin user' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe 'merchant dashboard' do
       expect(page).to_not have_css("#order-#{@o4.id}")
     end
 
+    it 'shows items without pictures within to-do list' do
+      within '.to-do-list' do
+        within '#items-without-pictures' do
+          expect(page).to have_content("Items with pictures are much more likely to be viewed!  Add photos for these items to increase sales:")
+          expect(page).to have_content(@i1.name)
+          expect(page).to have_content(@i2.name)
+        end
+      end
+    end
+
     describe 'shows a link to merchant items' do
       scenario 'as a merchant' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -104,12 +104,17 @@ RSpec.describe 'merchant dashboard' do
       expect(page).to_not have_css("#order-#{@o4.id}")
     end
 
-    it 'shows items without pictures within to-do list' do
+    it 'shows links for items without pictures within to-do list' do
       within '.to-do-list' do
+
         within '#items-without-pictures' do
-          expect(page).to have_content("Items with pictures are much more likely to be viewed!  Add photos for these items to increase sales:")
-          expect(page).to have_content(@i1.name)
-          expect(page).to have_content(@i2.name)
+          expect(page).to have_content("Add photos for these items to increase sales:")
+          expect(page).to have_link(@i1.name)
+          expect(page).to have_link(@i2.name)
+
+          click_link "#{@i1.name}"
+
+          expect(current_path).to eq(item_path(@i1))
         end
       end
     end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -4,10 +4,13 @@ RSpec.describe 'merchant dashboard' do
   before :each do
     @merchant = create(:merchant)
     @admin = create(:admin)
+
     @i1, @i2 = create_list(:item, 2, user: @merchant)
     @o1, @o2 = create_list(:order, 2)
+
     @o3 = create(:shipped_order)
     @o4 = create(:cancelled_order)
+
     create(:order_item, order: @o1, item: @i1, quantity: 1, price: 2)
     create(:order_item, order: @o1, item: @i2, quantity: 2, price: 2)
     create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
@@ -19,13 +22,18 @@ RSpec.describe 'merchant dashboard' do
     describe 'shows merchant information' do
       scenario 'as a merchant' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
         visit dashboard_path
+
         expect(page).to_not have_button("Downgrade to User")
       end
+
       scenario 'as an admin' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
         visit admin_merchant_path(@merchant)
       end
+
       after :each do
         expect(page).to have_content(@merchant.name)
         expect(page).to have_content("Email: #{@merchant.email}")
@@ -33,6 +41,24 @@ RSpec.describe 'merchant dashboard' do
         expect(page).to have_content("City: #{@merchant.city}")
         expect(page).to have_content("State: #{@merchant.state}")
         expect(page).to have_content("Zip: #{@merchant.zip}")
+      end
+    end
+
+    describe 'shows to-do list' do
+      scenario 'as a merchant' do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+        visit dashboard_path
+
+        expect(page).to have_css(".to-do-list")
+        end
+
+      scenario 'as an admin user' do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+        visit admin_merchant_path(@merchant)
+
+        expect(page).to_not have_css(".to-do-list")
       end
     end
   end
@@ -43,6 +69,7 @@ RSpec.describe 'merchant dashboard' do
 
       visit dashboard_path
     end
+
     it 'shows merchant information' do
       expect(page).to have_content(@merchant.name)
       expect(page).to have_content("Email: #{@merchant.email}")
@@ -63,6 +90,7 @@ RSpec.describe 'merchant dashboard' do
         expect(page).to have_content(@o1.total_quantity_for_merchant(@merchant.id))
         expect(page).to have_content(@o1.total_price_for_merchant(@merchant.id))
       end
+
       within("#order-#{@o2.id}") do
         expect(page).to have_link(@o2.id)
         expect(page).to have_content(@o2.created_at)
@@ -79,15 +107,23 @@ RSpec.describe 'merchant dashboard' do
     describe 'shows a link to merchant items' do
       scenario 'as a merchant' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
         visit dashboard_path
+
         click_link('Items for Sale')
+
         expect(current_path).to eq(dashboard_items_path)
       end
+
       scenario 'as an admin' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
         visit admin_merchant_path(@merchant)
+
         expect(page.status_code).to eq(200)
+
         click_link('Items for Sale')
+
         expect(current_path).to eq(admin_merchant_items_path(@merchant))
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,37 +16,39 @@ RSpec.describe Item, type: :model do
   end
 
   describe 'class methods' do
-    describe 'item popularity' do
-      before :each do
-        merchant = create(:merchant)
-        @items = create_list(:item, 6, user: merchant)
-        user = create(:user)
+    before :each do
+      merchant = create(:merchant)
+      @items = create_list(:item, 6, user: merchant)
+      user = create(:user)
 
-        order = create(:shipped_order, user: user)
-        create(:fulfilled_order_item, order: order, item: @items[3], quantity: 7)
-        create(:fulfilled_order_item, order: order, item: @items[1], quantity: 6)
-        create(:fulfilled_order_item, order: order, item: @items[0], quantity: 5)
-        create(:fulfilled_order_item, order: order, item: @items[2], quantity: 3)
-        create(:fulfilled_order_item, order: order, item: @items[5], quantity: 2)
-        create(:fulfilled_order_item, order: order, item: @items[4], quantity: 1)
-      end
+      order = create(:shipped_order, user: user)
+      create(:fulfilled_order_item, order: order, item: @items[3], quantity: 7)
+      create(:fulfilled_order_item, order: order, item: @items[1], quantity: 6)
+      create(:fulfilled_order_item, order: order, item: @items[0], quantity: 5)
+      create(:fulfilled_order_item, order: order, item: @items[2], quantity: 3)
+      create(:fulfilled_order_item, order: order, item: @items[5], quantity: 2)
+      create(:fulfilled_order_item, order: order, item: @items[4], quantity: 1)
+    end
 
-      it '.item_popularity' do
-        expect(Item.item_popularity(4, :desc)).to eq([@items[3], @items[1], @items[0], @items[2]])
-        expect(Item.item_popularity(4, :asc)).to eq([@items[4], @items[5], @items[2], @items[0]])
-      end
+    it '.item_popularity' do
+      expect(Item.item_popularity(4, :desc)).to eq([@items[3], @items[1], @items[0], @items[2]])
+      expect(Item.item_popularity(4, :asc)).to eq([@items[4], @items[5], @items[2], @items[0]])
+    end
 
-      it '.popular_items' do
-        actual = Item.popular_items(3)
-        expect(actual).to eq([@items[3], @items[1], @items[0]])
-        expect(actual[0].total_ordered).to eq(7)
-      end
+    it '.popular_items' do
+      actual = Item.popular_items(3)
+      expect(actual).to eq([@items[3], @items[1], @items[0]])
+      expect(actual[0].total_ordered).to eq(7)
+    end
 
-      it '.unpopular_items' do
-        actual = Item.unpopular_items(3)
-        expect(actual).to eq([@items[4], @items[5], @items[2]])
-        expect(actual[0].total_ordered).to eq(1)
-      end
+    it '.unpopular_items' do
+      actual = Item.unpopular_items(3)
+      expect(actual).to eq([@items[4], @items[5], @items[2]])
+      expect(actual[0].total_ordered).to eq(1)
+    end
+
+    it '.items_without_pictures' do
+      expect(Item.items_without_pictures).to eq([@items[0], @items[1], @items[2], @items[3], @items[4], @items[5]])
     end
   end
 


### PR DESCRIPTION
This PR adds the structure for a merchant to-do list, as well as the "items without images" section of the to-do list.

- Add structure for to-do list and "items without images" section to dashboard HTML
- Add feature specs for merchant seeing to-do list and "items without images"
- Add feature spec for admin NOT seeing to-do list
- Add items_without_images class method and spec to Item model
- Add items_without_images IVAR to DashboardController