### PR TITLE
Merchant Unfulfilled Item Stats

### DIFF
--- a/app/controllers/dashboard/dashboard_controller.rb
+++ b/app/controllers/dashboard/dashboard_controller.rb
@@ -2,6 +2,6 @@ class Dashboard::DashboardController < Dashboard::BaseController
   def index
     @merchant = current_user
     @pending_orders = Order.pending_orders_for_merchant(current_user.id)
-    @items_without_pictures = Item.items_without_pictures
+    @items_without_pictures = @merchant.items_without_pictures
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -31,12 +31,6 @@ class Item < ApplicationRecord
     .limit(limit)
   end
 
-  def self.items_without_pictures
-    default_image_url = "%https://picsum.photos/%"
-
-    where("items.image LIKE ?", default_image_url).order(:name)
-  end
-
   def convert_datetime_to_seconds(datetime)
     days_and_hours = datetime.split(":").first
     days = days_and_hours.split.first.to_i

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,12 +16,13 @@ class Order < ApplicationRecord
     oi.sum
   end
 
-  def self.pending_orders_for_merchant(merchant_id)
-    self.joins(:items)
-        .where(status: :pending)
-        .where(items: {merchant_id: merchant_id})
-        .distinct
+  def self.revenue_for_merchant(merchant_id)
+    select('items.id, order_items.quantity, order_items.price')
+    .joins(:items)
+    .where(items: {merchant_id: merchant_id})
+    .sum('order_items.quantity * order_items.price')
   end
+
 
   def total_quantity_for_merchant(merchant_id)
     items.joins(:order_items)
@@ -39,9 +40,17 @@ class Order < ApplicationRecord
          .sum('order_items.quantity * order_items.price')
   end
 
+
   def order_items_for_merchant(merchant_id)
     order_items.joins(:item)
                .where(items: {merchant_id: merchant_id})
+  end
+
+  def self.pending_orders_for_merchant(merchant_id)
+    self.joins(:items)
+    .where(status: :pending)
+    .where(items: {merchant_id: merchant_id})
+    .distinct
   end
 
   def self.orders_by_status(status)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,14 @@ class User < ApplicationRecord
     items.where(active: true).order(:name)
   end
 
+  def items_without_pictures
+    default_image_url = "%https://picsum.photos/%"
+
+    items.where(active: true)
+    .where('items.image LIKE ?', default_image_url)
+    .order(:name)
+  end
+
   def top_items_sold_by_quantity(limit)
     items.joins(order_items: :order)
          .where(order_items: {fulfilled: true}, orders: {status: :shipped})

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -20,7 +20,7 @@
     <section id="items-without-pictures">
       <p>Add photos for these items to increase sales:</p>
       <% @items_without_pictures.each do |item| %>
-        <p><%= link_to item.name, item_path(item) %></p>
+        <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
       <% end %>
     </section>
     <% end %>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -24,6 +24,11 @@
       <% end %>
     </section>
     <% end %>
+    <% if @pending_orders %>
+    <section id="unfulfilled-item-revenue">
+      <p>You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
+    </section>
+    <% end %>
   </div>
 <% end %>
 

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe 'merchant dashboard' do
 
     it 'shows a statistic about unfulfilled items and revenue impact' do
       within '.to-do-list' do
-        save_and_open_page
         within '#unfulfilled-item-revenue' do
           expect(page).to have_content("You have 2 unfulfilled orders worth $14.00!")
         end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'merchant dashboard' do
       expect(page).to_not have_css("#order-#{@o4.id}")
     end
 
-    it 'shows links for items without pictures within to-do list' do
+    it 'shows links to edit pages for items without pictures within to-do list' do
       within '.to-do-list' do
 
         within '#items-without-pictures' do
@@ -114,7 +114,7 @@ RSpec.describe 'merchant dashboard' do
 
           click_link "#{@i1.name}"
 
-          expect(current_path).to eq(item_path(@i1))
+          expect(current_path).to eq(edit_dashboard_item_path(@i1))
         end
       end
     end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe 'merchant dashboard' do
 
     it 'shows links to edit pages for items without pictures within to-do list' do
       within '.to-do-list' do
-
         within '#items-without-pictures' do
           expect(page).to have_content("Add photos for these items to increase sales:")
           expect(page).to have_link(@i1.name)
@@ -115,6 +114,15 @@ RSpec.describe 'merchant dashboard' do
           click_link "#{@i1.name}"
 
           expect(current_path).to eq(edit_dashboard_item_path(@i1))
+        end
+      end
+    end
+
+    it 'shows a statistic about unfulfilled items and revenue impact' do
+      within '.to-do-list' do
+        save_and_open_page
+        within '#unfulfilled-item-revenue' do
+          expect(page).to have_content("You have 2 unfulfilled orders worth $14.00")
         end
       end
     end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'merchant dashboard' do
       within '.to-do-list' do
         save_and_open_page
         within '#unfulfilled-item-revenue' do
-          expect(page).to have_content("You have 2 unfulfilled orders worth $14.00")
+          expect(page).to have_content("You have 2 unfulfilled orders worth $14.00!")
         end
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -46,10 +46,6 @@ RSpec.describe Item, type: :model do
       expect(actual).to eq([@items[4], @items[5], @items[2]])
       expect(actual[0].total_ordered).to eq(1)
     end
-
-    it '.items_without_pictures' do
-      expect(Item.items_without_pictures).to eq([@items[0], @items[1], @items[2], @items[3], @items[4], @items[5]])
-    end
   end
 
   describe 'instance methods' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -80,21 +80,29 @@ RSpec.describe Order, type: :model do
       expect(Order.pending_orders_for_merchant(@merchant.id)).to eq([@o7, @o8])
     end
 
+    it ".revenue_for_merchant" do
+      expect(Order.revenue_for_merchant(@merchant.id)).to eq(492.00)
+    end
+
     it '.orders_by_status(status)' do
       expect(Order.orders_by_status(:pending)).to eq([@o7, @o8])
       expect(Order.orders_by_status(:packaged)).to eq([@packaged_orders[0], @packaged_orders[1], @packaged_orders[2]])
       expect(Order.orders_by_status(:shipped)).to eq([@o1, @o2, @o3, @o4, @o5, @o6])
       expect(Order.orders_by_status(:cancelled)).to eq([@cancelled_orders[0], @cancelled_orders[1]])
     end
+
     it '.pending_orders' do
       expect(Order.pending_orders).to eq([@o7, @o8])
     end
+
     it '.packaged_orders' do
       expect(Order.packaged_orders).to eq([@packaged_orders[0], @packaged_orders[1], @packaged_orders[2]])
     end
+
     it '.shipped_orders' do
       expect(Order.shipped_orders).to eq([@o1, @o2, @o3, @o4, @o5, @o6])
     end
+
     it '.cancelled_orders' do
       expect(Order.cancelled_orders).to eq([@cancelled_orders[0], @cancelled_orders[1]])
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe User, type: :model do
       @oi7.fulfill
     end
 
+    it '.items_without_pictures' do
+      expect(@m1.items_without_pictures).to eq([@i1, @i2, @i3, @i4, @i5, @i6, @i7, @i8])
+    end
+
     it '.active_items' do
       expect(@m2.active_items).to eq([@i10])
       expect(@m1.active_items).to eq([@i1, @i2, @i3, @i4, @i5, @i6, @i7, @i8])


### PR DESCRIPTION
This PR adds unfulfilled item stats to the merchant dashboard to-do list.

- Refactor items_without_images to use User model instead of Item model
- Add revenue_for_merchant class method and spec to Order model
- Add feature spec for Merchant seeing unfulfilled item stats with revenue
- Add unfulfilled item stats to merchant dashboard view