### PR TITLE
Insufficient Inventory Warning

### DIFF
--- a/app/controllers/dashboard/dashboard_controller.rb
+++ b/app/controllers/dashboard/dashboard_controller.rb
@@ -3,5 +3,6 @@ class Dashboard::DashboardController < Dashboard::BaseController
     @merchant = current_user
     @pending_orders = Order.pending_orders_for_merchant(current_user.id)
     @items_without_pictures = @merchant.items_without_pictures
+    @insufficient_items = @merchant.insufficient_items
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -23,6 +23,9 @@ class Order < ApplicationRecord
     .sum('order_items.quantity * order_items.price')
   end
 
+  def insufficient_inventory?
+    order_items.any? {|order_item| order_item.inventory_unavailable}
+  end
 
   def total_quantity_for_merchant(merchant_id)
     items.joins(:order_items)

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -27,4 +27,8 @@ class OrderItem < ApplicationRecord
   def inventory_available
     item.inventory >= quantity
   end
+
+  def inventory_unavailable
+    item.inventory < quantity
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
     items.where(active: true).order(:name)
   end
 
+  def insufficient_items
+    quantified_items.find_all {|item| item.inventory < item.total_quantity}
+  end
+  
   def items_without_pictures
     default_image_url = "%https://picsum.photos/%"
 
@@ -162,5 +166,15 @@ class User < ApplicationRecord
         .select('users.city, users.state, count(orders.id) AS order_count')
         .order('order_count DESC')
         .limit(limit)
+  end
+
+  private
+
+  def quantified_items
+    items.select('items.*, SUM(order_items.quantity) AS total_quantity')
+    .joins(order_items: :order)
+    .where(orders: {status: :pending})
+    .order(:name)
+    .group(:id)
   end
 end

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Merchant Dashboard</h1>
 
-<div class="card float-left m-3 order-item-card">
+<div class="card float-left m-2 order-item-card">
   <div class="card-body">
     <h5 class="card-title"><%= @merchant.name %></h5>
     <p>Role: <%= @merchant.role %></p>
@@ -10,38 +10,51 @@
     <p>State: <%= @merchant.state %></p>
     <p>Zip: <%= @merchant.zip %></p>
     <%= button_to 'Downgrade to User', admin_downgrade_merchant_path(@merchant), method: :patch if current_admin? %>
+    <section>
+      <p>
+      <% if current_merchant? && current_user == @merchant %>
+        <%= link_to 'Items for Sale', dashboard_items_path %>
+      <% elsif current_admin? %>
+        <%= link_to 'Items for Sale', admin_merchant_items_path(@merchant) %>
+      <% end %>
+      </p>
+    </section>
   </div>
 </div>
 
 <% if current_merchant? %>
-  <div class="to-do-list">
-    <h5>To-Do List</h5>
-    <% unless @items_without_pictures.empty? %>
-    <section id="items-without-pictures">
-      <p>Add photos for these items to increase sales:</p>
-      <% @items_without_pictures.each do |item| %>
-        <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
-      <% end %>
-    </section>
+  <%= tag.div class: "card" do %>
+    <%= tag.section class: "to-do card-body float-right m-2" do %>
+      <div class="to-do-list">
+        <h5>To-Do List</h5>
+        <% unless @items_without_pictures.empty? %>
+        <section id="items-without-pictures">
+          <p>Add photos for these items to increase sales:</p>
+          <% @items_without_pictures.each do |item| %>
+            <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
+          <% end %>
+        </section>
+        <% end %>
+        <% unless @insufficient_items.empty? %>
+        <section id="items-with-insufficient-inventory">
+          <p style="color:red;">"These items have insufficient inventory to fulfill all orders and need to be restocked:"</p>
+          <% @insufficient_items.each do |item| %>
+            <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
+          <% end %>
+        </section>
+        <% end %>
+        <% unless @pending_orders.empty? %>
+        <section id="unfulfilled-item-revenue">
+          <p style="color:red;">You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
+        </section>
+        <% end %>
+      </div>
     <% end %>
-    <% unless @insufficient_items.empty? %>
-    <section id="items-with-insufficient-inventory">
-      <p style="color:red;">"These items have insufficient inventory to fulfill all orders and need to be restocked:"</p>
-      <% @insufficient_items.each do |item| %>
-        <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
-      <% end %>
-    </section>
-    <% end %>
-    <% unless @pending_orders.empty? %>
-    <section id="unfulfilled-item-revenue">
-      <p style="color:red;">You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
-    </section>
-    <% end %>
-  </div>
+  <% end %>
 <% end %>
 
 <%= tag.div class: "card" do %>
-  <%= tag.section class: "statistics card-body float-left m-4" do %>
+  <%= tag.section class: "statistics card-body float-left m-2" do %>
     <%= tag.section id: "top-items-sold-by-quantity", class: "card-body float-left m-2" do %>
       <h5 class="card-title">Top Items Sold by Quantity</h5>
       <ul>
@@ -96,16 +109,6 @@
     <% end %>
   <% end %>
 <% end %>
-
-<section>
-  <p>
-  <% if current_merchant? && current_user == @merchant %>
-  <%= link_to 'Items for Sale', dashboard_items_path %>
-  <% elsif current_admin? %>
-  <%= link_to 'Items for Sale', admin_merchant_items_path(@merchant) %>
-  <% end %>
-  </p>
-</section>
 
 <% if @pending_orders %>
   <table class="table">

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </section>
     <% end %>
-    <% if @pending_orders %>
+    <% unless @pending_orders.empty? %>
     <section id="unfulfilled-item-revenue">
       <p>You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
     </section>
@@ -107,6 +107,7 @@
         <th>Created Date</th>
         <th>Quantity</th>
         <th>Price</th>
+        <th>Notes</th>
       </tr>
     </thead>
     <tbody>
@@ -120,6 +121,11 @@
           <td><%= order.created_at %></td>
           <td><%= order.total_quantity_for_merchant(@merchant.id) %></td>
           <td><%= order.total_price_for_merchant(@merchant.id) %></td>
+          <td style="color:red;">
+            <% if order.insufficient_inventory? %>
+              Insufficient inventory to fulfill!
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -24,10 +24,10 @@
       <% end %>
     </section>
     <% end %>
-    <% if @items_with_insufficient_inventory %>
+    <% if @insufficient_items %>
     <section id="items-with-insufficient-inventory">
       <p style="color:red;">These items have insufficient inventory need to be restocked:</p>
-      <% @items_with_insufficient_inventory.each do |item| %>
+      <% @insufficient_items.each do |item| %>
         <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
       <% end %>
     </section>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -16,7 +16,7 @@
 <% if current_merchant? %>
   <div class="to-do-list">
     <h5>To-Do List</h5>
-    <% if @items_without_pictures %>
+    <% unless @items_without_pictures.empty? %>
     <section id="items-without-pictures">
       <p>Add photos for these items to increase sales:</p>
       <% @items_without_pictures.each do |item| %>
@@ -24,9 +24,9 @@
       <% end %>
     </section>
     <% end %>
-    <% if @insufficient_items %>
+    <% unless @insufficient_items.empty? %>
     <section id="items-with-insufficient-inventory">
-      <p style="color:red;">These items have insufficient inventory need to be restocked:</p>
+      <p style="color:red;">"These items have insufficient inventory to fulfill all orders and need to be restocked:"</p>
       <% @insufficient_items.each do |item| %>
         <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
       <% end %>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -24,9 +24,17 @@
       <% end %>
     </section>
     <% end %>
+    <% if @items_with_insufficient_inventory %>
+    <section id="items-with-insufficient-inventory">
+      <p style="color:red;">These items have insufficient inventory need to be restocked:</p>
+      <% @items_with_insufficient_inventory.each do |item| %>
+        <p><%= link_to item.name, edit_dashboard_item_path(item) %></p>
+      <% end %>
+    </section>
+    <% end %>
     <% unless @pending_orders.empty? %>
     <section id="unfulfilled-item-revenue">
-      <p>You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
+      <p style="color:red;">You have <%= pluralize(@pending_orders.count, 'unfulfilled order') %> worth <%= number_to_currency(@pending_orders.revenue_for_merchant(@merchant)) %>!</p>
     </section>
     <% end %>
   </div>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'merchant dashboard' do
     @merchant = create(:merchant)
     @admin = create(:admin)
 
-    @i1, @i2 = create_list(:item, 2, user: @merchant)
-    @o1, @o2 = create_list(:order, 2)
+    @i1, @i2, @i3, @i4 = create_list(:item, 4, user: @merchant)
+    @o1, @o2, @o5, @o6 = create_list(:order, 4)
 
     @o3 = create(:shipped_order)
     @o4 = create(:cancelled_order)
@@ -16,6 +16,10 @@ RSpec.describe 'merchant dashboard' do
     create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
     create(:order_item, order: @o3, item: @i1, quantity: 4, price: 2)
     create(:order_item, order: @o4, item: @i2, quantity: 5, price: 2)
+    create(:order_item, order: @o5, item: @i3, quantity: 8, price: 2)
+    create(:order_item, order: @o5, item: @i4, quantity: 10, price: 2)
+    create(:order_item, order: @o6, item: @i3, quantity: 8, price: 2)
+    create(:order_item, order: @o6, item: @i4, quantity: 12, price: 2)
   end
 
   describe 'merchant user visits their profile' do
@@ -99,6 +103,24 @@ RSpec.describe 'merchant dashboard' do
       end
     end
 
+    it 'shows a warning beside pending orders current inventory cannot cover' do
+      within("#order-#{@o6.id}") do
+        expect(page).to have_content("Current inventory is too low to fulfill!")
+      end
+
+      within("#order-#{@o1.id}") do
+        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+      end
+
+      within("#order-#{@o2.id}") do
+        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+      end
+
+      within("#order-#{@o5.id}") do
+        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+      end
+    end
+
     it 'does not show non-pending orders' do
       expect(page).to_not have_css("#order-#{@o3.id}")
       expect(page).to_not have_css("#order-#{@o4.id}")
@@ -121,7 +143,7 @@ RSpec.describe 'merchant dashboard' do
     it 'shows a statistic about unfulfilled items and revenue impact' do
       within '.to-do-list' do
         within '#unfulfilled-item-revenue' do
-          expect(page).to have_content("You have 2 unfulfilled orders worth $14.00!")
+          expect(page).to have_content("You have 4 unfulfilled orders worth $74.00!")
         end
       end
     end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe 'merchant dashboard' do
     end
 
     it 'shows a warning beside pending orders current inventory cannot cover' do
-      save_and_open_page
       within("#order-#{@o6.id}") do
         expect(page).to have_content("Insufficient inventory to fulfill!")
       end
@@ -131,12 +130,27 @@ RSpec.describe 'merchant dashboard' do
       within '.to-do-list' do
         within '#items-without-pictures' do
           expect(page).to have_content("Add photos for these items to increase sales:")
+
           expect(page).to have_link(@i1.name)
           expect(page).to have_link(@i2.name)
 
           click_link "#{@i1.name}"
 
           expect(current_path).to eq(edit_dashboard_item_path(@i1))
+        end
+      end
+    end
+
+    it 'shows items that have insufficient inventory to fulfill all orders' do
+      within '.to-do-list' do
+        within '#items-with-insufficient-inventory' do
+          expect(page).to have_content("These items have insufficient inventory need to be restocked:")
+
+          expect(page).to have_link(@i3.name)
+          expect(page).to have_link(@i4.name)
+
+          expect(page).to_not have_link(@i1.name)
+          expect(page).to_not have_link(@i2.name)
         end
       end
     end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -104,20 +104,21 @@ RSpec.describe 'merchant dashboard' do
     end
 
     it 'shows a warning beside pending orders current inventory cannot cover' do
+      save_and_open_page
       within("#order-#{@o6.id}") do
-        expect(page).to have_content("Current inventory is too low to fulfill!")
+        expect(page).to have_content("Insufficient inventory to fulfill!")
       end
 
       within("#order-#{@o1.id}") do
-        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+        expect(page).to_not have_content("Insufficient inventory to fulfill!")
       end
 
       within("#order-#{@o2.id}") do
-        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+        expect(page).to_not have_content("Insufficient inventory to fulfill!")
       end
 
       within("#order-#{@o5.id}") do
-        expect(page).to_not have_content("Current inventory is too low to fulfill!")
+        expect(page).to_not have_content("Insufficient inventory to fulfill!")
       end
     end
 

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'merchant dashboard' do
     it 'shows items that have insufficient inventory to fulfill all orders' do
       within '.to-do-list' do
         within '#items-with-insufficient-inventory' do
-          expect(page).to have_content("These items have insufficient inventory need to be restocked:")
+          expect(page).to have_content("These items have insufficient inventory to fulfill all orders and need to be restocked:")
 
           expect(page).to have_link(@i3.name)
           expect(page).to have_link(@i4.name)

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe OrderItem, type: :model do
       expect(item.inventory).to eq(0)
     end
 
-    it 'inventory_available' do
-      item = create(:item, inventory:2)
+    it '.inventory_available' do
+      item = create(:item, inventory: 2)
       oi1 = create(:order_item, quantity: 1, item: item)
       oi2 = create(:order_item, quantity: 2, item: item)
       oi3 = create(:order_item, quantity: 3, item: item)
@@ -57,6 +57,17 @@ RSpec.describe OrderItem, type: :model do
       expect(oi1.inventory_available).to eq(true)
       expect(oi2.inventory_available).to eq(true)
       expect(oi3.inventory_available).to eq(false)
+    end
+
+    it '.inventory_unvailable' do
+      item = create(:item, inventory: 2)
+      oi1 = create(:order_item, quantity: 1, item: item)
+      oi2 = create(:order_item, quantity: 2, item: item)
+      oi3 = create(:order_item, quantity: 3, item: item)
+
+      expect(oi1.inventory_unavailable).to eq(false)
+      expect(oi2.inventory_unavailable).to eq(false)
+      expect(oi3.inventory_unavailable).to eq(true)
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -19,16 +19,20 @@ RSpec.describe Order, type: :model do
       yesterday = 1.day.ago
 
       @order = create(:order, user: user, created_at: yesterday)
+
       @oi_1 = create(:order_item, order: @order, item: @item_1, price: 1, quantity: 1, created_at: yesterday, updated_at: yesterday)
       @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, price: 2, quantity: 1, created_at: yesterday, updated_at: 2.hours.ago)
 
       @merchant = create(:merchant)
+
       @i1, @i2 = create_list(:item, 2, user: @merchant)
+
       @o1, @o2 = create_list(:order, 2)
       @o3 = create(:packaged_order)
       @o4 = create(:shipped_order)
       @o5 = create(:cancelled_order)
-      create(:order_item, order: @o1, item: @i1, quantity: 1, price: 2)
+
+      create(:order_item, order: @o1, item: @i1, quantity: 100, price: 2)
       create(:order_item, order: @o1, item: @i2, quantity: 2, price: 2)
       create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
       create(:order_item, order: @o3, item: @i1, quantity: 4, price: 2)
@@ -42,6 +46,11 @@ RSpec.describe Order, type: :model do
 
     it '.total_cost' do
       expect(@order.total_cost).to eq((@oi_1.quantity*@oi_1.price) + (@oi_2.quantity*@oi_2.price))
+    end
+
+    it ".insufficient_inventory?" do
+      expect(@o1.insufficient_inventory?).to eq(true)
+      expect(@o2.insufficient_inventory?).to eq(false)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe User, type: :model do
       u6 = create(:user, state: "IA", city: "Des Moines")
 
       @m1 = create(:merchant)
+
       @i1 = create(:item, merchant_id: @m1.id, inventory: 20)
       @i2 = create(:item, merchant_id: @m1.id, inventory: 20)
       @i3 = create(:item, merchant_id: @m1.id, inventory: 20)
@@ -85,8 +86,11 @@ RSpec.describe User, type: :model do
       @i7 = create(:item, merchant_id: @m1.id, inventory: 20)
       @i8 = create(:item, merchant_id: @m1.id, inventory: 20)
       @i9 = create(:inactive_item, merchant_id: @m1.id)
+      @i11 = create(:item, merchant_id: @m1.id, inventory: 3)
+      @i12 = create(:item, merchant_id: @m1.id, inventory: 1)
 
       @m2 = create(:merchant)
+
       @i10 = create(:item, merchant_id: @m2.id, inventory: 20)
 
       o1 = create(:shipped_order, user: @u1)
@@ -96,6 +100,9 @@ RSpec.describe User, type: :model do
       o5 = create(:shipped_order, user: @u1)
       o6 = create(:cancelled_order, user: u5)
       o7 = create(:order, user: u6)
+      o8 = create(:order, user: u6)
+      o9 = create(:order, user: u6)
+
       @oi1 = create(:order_item, item: @i1, order: o1, quantity: 2, created_at: 1.days.ago)
       @oi2 = create(:order_item, item: @i2, order: o2, quantity: 8, created_at: 7.days.ago)
       @oi3 = create(:order_item, item: @i2, order: o3, quantity: 6, created_at: 7.days.ago)
@@ -103,6 +110,10 @@ RSpec.describe User, type: :model do
       @oi5 = create(:order_item, item: @i4, order: o4, quantity: 3, created_at: 4.days.ago)
       @oi6 = create(:order_item, item: @i5, order: o5, quantity: 1, created_at: 5.days.ago)
       @oi7 = create(:order_item, item: @i6, order: o6, quantity: 2, created_at: 3.days.ago)
+      @oi8 = create(:order_item, item: @i11, order: o8, quantity: 2, created_at: 3.days.ago)
+      @oi9 = create(:order_item, item: @i11, order: o9, quantity: 2, created_at: 3.days.ago)
+      @oi10 = create(:order_item, item: @i12, order: o9, quantity: 2, created_at: 3.days.ago)
+
       @oi1.fulfill
       @oi2.fulfill
       @oi3.fulfill
@@ -112,13 +123,17 @@ RSpec.describe User, type: :model do
       @oi7.fulfill
     end
 
+    it ".insufficient_items" do
+      expect(@m1.insufficient_items). to eq([@i12, @i11])
+    end
+
     it '.items_without_pictures' do
-      expect(@m1.items_without_pictures).to eq([@i1, @i2, @i3, @i4, @i5, @i6, @i7, @i8])
+      expect(@m1.items_without_pictures).to eq([@i1, @i12, @i2, @i3, @i4, @i5, @i6, @i7, @i8, @i11])
     end
 
     it '.active_items' do
       expect(@m2.active_items).to eq([@i10])
-      expect(@m1.active_items).to eq([@i1, @i2, @i3, @i4, @i5, @i6, @i7, @i8])
+      expect(@m1.active_items).to eq([@i1, @i12, @i2, @i3, @i4, @i5, @i6, @i7, @i8, @i11])
     end
 
     it '.top_items_sold_by_quantity' do
@@ -140,11 +155,11 @@ RSpec.describe User, type: :model do
     end
 
     it '.percent_of_items_sold' do
-      expect(@m1.percent_of_items_sold.round(2)).to eq(17.39)
+      expect(@m1.percent_of_items_sold.round(2)).to eq(16.9)
     end
 
     it '.total_inventory_remaining' do
-      expect(@m1.total_inventory_remaining).to eq(138)
+      expect(@m1.total_inventory_remaining).to eq(142)
     end
 
     it '.top_states_by_items_shipped' do


### PR DESCRIPTION
This PR adds insufficient inventory warnings to the merchant dashboard.

- Add inventory_unavailable instance method and spec to OrderItem model
- Add insufficient_inventory? instance method and spec to Order model
- Add feature spec for merchant seeing a link to all items with insufficient inventory
- Add quantified_items and insufficient_items methods to User model
- Add insufficient inventory warnings to merchant dashboard view