### PR TITLE
User Changes Used Address

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,6 @@
 class Address < ApplicationRecord
   belongs_to :user
-  has_many :orders
+  has_many :orders, dependent: :destroy
 
   validates_presence_of :nickname, :address, :city, :state, :zip
   validates_uniqueness_of :nickname, scope: [:user_id]

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,4 +4,8 @@ class Address < ApplicationRecord
 
   validates_presence_of :nickname, :address, :city, :state, :zip
   validates_uniqueness_of :nickname, scope: [:user_id]
+
+  def not_ordered?
+    orders.where(status: [1, 2]).empty?
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@ class Order < ApplicationRecord
   belongs_to :address
   has_many :addresses
   has_many :order_items
-  has_many :items, through: :order_items
+  has_many :items, through: :order_items, dependent: :destroy
 
   validates_presence_of :status
 

--- a/app/views/profile/addresses/index.html.erb
+++ b/app/views/profile/addresses/index.html.erb
@@ -13,8 +13,10 @@
         <%= address.state %>
         <%= address.zip %>
       </p>
-      <%= link_to "Edit", edit_profile_address_path(address) %>
-      <%= link_to "Delete", "/profile/addresses/#{address.id}", method: :delete %>
+      <% if address.not_ordered? %>
+        <%= link_to "Edit", edit_profile_address_path(address) %>
+        <%= link_to "Delete", "/profile/addresses/#{address.id}", method: :delete, data: {confirm: "Deleting this address will destroy any pending orders associated with it.  Are you sure?"} %>
+      <% end %>
     </div>
     <% end %>
   </section>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -8,7 +8,7 @@
   <p>Shipping Address: <%= @order.address.nickname %> - <%= @order.address.address %>, <%= @order.address.city %>, <%= @order.address.state %> <%= @order.address.zip %></p>
 
   <% if @order.status == 'pending' || @order.status == 'packaged' %>
-  <p><%= button_to 'Cancel Order', profile_order_path(@order), method: :delete %></p>
+  <p><%= button_to 'Cancel Order', profile_order_path(@order), method: :delete, data: {confirm: "Are you sure you want to cancel this order?"} %></p>
     <% if current_user.address_count > 1 %>
       <p><%= button_to 'Change Shipping Address', order_address_path(@order), method: :get %></p>
     <% end %>

--- a/spec/features/users/addresses/profile_addresses_spec.rb
+++ b/spec/features/users/addresses/profile_addresses_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'Profile Addresses page', type: :feature do
   before :each do
     @user_1 = create(:user)
     @user_2 = create(:user)
+
+    @merchant = create(:merchant)
   end
 
   context 'as a registered user with no addresses' do
@@ -55,6 +57,25 @@ RSpec.describe 'Profile Addresses page', type: :feature do
       @address_2 = @user_1.addresses.create!(zip: "Zip 2", address: "Address 2", state: "State 2", city: "City 2", nickname: "Nickname 2")
       @address_3 = @user_1.addresses.create!(zip: "Zip 3", address: "Address 3", state: "State 3", city: "City 3", nickname: "Nickname 3")
       @address_4 = @user_1.addresses.create!(zip: "Zip 4", address: "Address 4", state: "State 4", city: "City 4", nickname: "Nickname 4")
+
+      @i1, @i2, @i3, @i4 = create_list(:item, 4, user: @merchant)
+
+      @o1 = create(:order, address: @address_1)
+      @o2 = create(:order, address: @address_2)
+      @o5 = create(:order, address: @address_3)
+      @o6 = create(:order, address: @address_4)
+      @o3 = create(:shipped_order, address: @address_1)
+      @o4 = create(:cancelled_order, address: @address_2)
+
+      create(:order_item, order: @o1, item: @i1, quantity: 1, price: 2)
+      create(:order_item, order: @o1, item: @i2, quantity: 2, price: 2)
+      create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
+      create(:order_item, order: @o3, item: @i1, quantity: 4, price: 2)
+      create(:order_item, order: @o4, item: @i2, quantity: 5, price: 2)
+      create(:order_item, order: @o5, item: @i3, quantity: 8, price: 2)
+      create(:order_item, order: @o5, item: @i4, quantity: 10, price: 2)
+      create(:order_item, order: @o6, item: @i3, quantity: 8, price: 2)
+      create(:order_item, order: @o6, item: @i4, quantity: 12, price: 2)
     end
 
     it 'the page should display all addresses for the user' do
@@ -83,13 +104,13 @@ RSpec.describe 'Profile Addresses page', type: :feature do
       end
     end
 
-      it 'the page should display a link to edit each address' do
+      it 'the page should display a link to edit addresses that have not been used in completed orders' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
         visit profile_addresses_path
 
         within "#address-#{@address_1.id}" do
-          expect(page).to have_link('Edit')
+          expect(page).to_not have_link('Edit')
         end
 
         within "#address-#{@address_2.id}" do
@@ -105,13 +126,13 @@ RSpec.describe 'Profile Addresses page', type: :feature do
         end
       end
 
-      it 'the page should display a link to delete each address' do
+      it 'the page should display a link to delete addresses that have not been used in completed orders' do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
         visit profile_addresses_path
 
         within "#address-#{@address_1.id}" do
-          expect(page).to have_link('Delete')
+          expect(page).to_not have_link('Delete')
         end
 
         within "#address-#{@address_2.id}" do
@@ -133,11 +154,11 @@ RSpec.describe 'Profile Addresses page', type: :feature do
 
           visit profile_addresses_path
 
-          within "#address-#{@address_1.id}" do
+          within "#address-#{@address_2.id}" do
             click_link 'Edit'
           end
 
-          expect(current_path).to eq(edit_profile_address_path(@address_1.id))
+          expect(current_path).to eq(edit_profile_address_path(@address_2.id))
         end
 
         describe "and fill out all the form correctly" do
@@ -154,7 +175,7 @@ RSpec.describe 'Profile Addresses page', type: :feature do
 
             visit profile_addresses_path
 
-            within "#address-#{@address_1.id}" do
+            within "#address-#{@address_2.id}" do
               click_link 'Edit'
             end
 
@@ -170,7 +191,7 @@ RSpec.describe 'Profile Addresses page', type: :feature do
 
             expect(page).to have_content("Address updated.")
 
-            within "#address-#{@address_1.id}" do
+            within "#address-#{@address_2.id}" do
               expect(page).to have_content(@updated_nickname)
               expect(page).to have_content("#{@updated_address} #{@updated_city}, #{@updated_state} #{@updated_zip}")
             end
@@ -191,7 +212,7 @@ RSpec.describe 'Profile Addresses page', type: :feature do
 
             visit profile_addresses_path
 
-            within "#address-#{@address_1.id}" do
+            within "#address-#{@address_2.id}" do
               click_link 'Edit'
             end
 
@@ -202,7 +223,7 @@ RSpec.describe 'Profile Addresses page', type: :feature do
             click_button 'Save Address'
 
             expect(page).to have_content(@updated_nickname)
-            expect(page).to have_content("#{@updated_address} #{@address_1.city}, #{@address_1.state} #{@updated_zip}")
+            expect(page).to have_content("#{@updated_address} #{@address_2.city}, #{@address_2.state} #{@updated_zip}")
           end
         end
       end
@@ -213,12 +234,12 @@ RSpec.describe 'Profile Addresses page', type: :feature do
 
           visit profile_addresses_path
 
-          within "#address-#{@address_1.id}" do
+          within "#address-#{@address_2.id}" do
             click_link 'Delete'
           end
 
           expect(page).to have_content("Address deleted.")
-          expect(page).to_not have_css("#address-#{@address_1.id}")
+          expect(page).to_not have_css("#address-#{@address_2.id}")
 
           expect(@user_1.addresses.count).to eq(3)
       end

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "the login page" do
     @merchant = create(:merchant)
     @admin = create(:admin)
 
+    @address = @merchant.addresses.create!(address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "Merchant Zip")
+
     visit login_path
   end
 

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'user profile', type: :feature do
 
         within '#address-details' do
           expect(page).to have_content("Addresses: #{@user.home_address.address} #{@user.home_address.city}, #{@user.home_address.state} #{@user.home_address.zip}")
-          expect(page).to have_content("#{@user.city}, #{@user.state} #{@user.zip}")
 
           expect(page).to have_link("Edit Addresses")
         end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -13,4 +13,38 @@ RSpec.describe Address, type: :model do
     it { should belong_to :user }
     it { should have_many :orders }
   end
+
+  describe "instance methods" do
+    before :each do
+      @merchant = create(:merchant)
+      @user = create(:user)
+
+      @address_1 = @user.addresses.create(nickname: "Nickname 1", address: 'Address 1', city: 'City 1', state: 'State 1', zip: 'Zip 1')
+      @address_2 = @user.addresses.create(nickname: "Nickname 2", address: 'Address 2', city: 'City 2', state: 'State 2', zip: 'Zip 2')
+
+      @i1, @i2, @i3, @i4 = create_list(:item, 4, user: @merchant)
+
+      @o1 = create(:order, address: @address_1)
+      @o2 = create(:order, address: @address_2)
+      @o5 = create(:order, address: @address_1)
+      @o6 = create(:order, address: @address_2)
+      @o3 = create(:shipped_order, address: @address_1)
+      @o4 = create(:cancelled_order, address: @address_1)
+
+      create(:order_item, order: @o1, item: @i1, quantity: 1, price: 2)
+      create(:order_item, order: @o1, item: @i2, quantity: 2, price: 2)
+      create(:order_item, order: @o2, item: @i2, quantity: 4, price: 2)
+      create(:order_item, order: @o3, item: @i1, quantity: 4, price: 2)
+      create(:order_item, order: @o4, item: @i2, quantity: 5, price: 2)
+      create(:order_item, order: @o5, item: @i3, quantity: 8, price: 2)
+      create(:order_item, order: @o5, item: @i4, quantity: 10, price: 2)
+      create(:order_item, order: @o6, item: @i3, quantity: 8, price: 2)
+      create(:order_item, order: @o6, item: @i4, quantity: 12, price: 2)
+    end
+
+    it ".not_ordered?" do
+      expect(@address_2.not_ordered?).to eq(true)
+      expect(@address_1.not_ordered?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This PR removes the User's ability to modify addresses for that have been used in completed orders.

- Add not_ordered? method and spec to Address model
- Add conditional to address edit/delete buttons in address index view
- Add feature spec for User no longer being able to see edit/delete buttons